### PR TITLE
Add `--keyserver` to GPG due to #2

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -38,7 +38,7 @@ RUN groupadd idp && \
                         http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz.asc \
                         http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$JETTY_VERSION/jetty-distribution-$JETTY_VERSION.tar.gz.asc.sha1 && \
     echo `cat /opt/src/jetty-distribution-$JETTY_VERSION.tar.gz.sha1` /opt/src/jetty-distribution-$JETTY_VERSION.tar.gz | sha1sum -c && \
-    gpg --recv-keys $JETTY_KEY && \
+    gpg --keyserver pgp.mit.edu --recv-keys $JETTY_KEY && \
     gpg --verify /opt/src/jetty-distribution-$JETTY_VERSION.tar.gz.asc && \
     tar -xzf /opt/src/jetty-distribution-$JETTY_VERSION.tar.gz -C /opt && \
     chown -R idp:idp /opt/jetty-distribution-$JETTY_VERSION && \
@@ -77,7 +77,7 @@ RUN wget -q -P /opt/src/ https://shibboleth.net/downloads/identity-provider/$SHI
                          https://shibboleth.net/downloads/identity-provider/$SHIBBOLETH_VERSION/shibboleth-identity-provider-$SHIBBOLETH_VERSION.tar.gz.asc \
                          https://shibboleth.net/downloads/identity-provider/$SHIBBOLETH_VERSION/shibboleth-identity-provider-$SHIBBOLETH_VERSION.tar.gz.sha256 && \
     cd /opt/src && sha256sum -c shibboleth-identity-provider-$SHIBBOLETH_VERSION.tar.gz.sha256 && \
-    gpg --recv-keys $SHIBBOLETH_KEY && \
+    gpg --keyserver pgp.mit.edu --recv-keys $SHIBBOLETH_KEY && \
     gpg --verify /opt/src/shibboleth-identity-provider-$SHIBBOLETH_VERSION.tar.gz.asc && \
     tar -xzf /opt/src/shibboleth-identity-provider-$SHIBBOLETH_VERSION.tar.gz -C /opt && \
     echo idp.no.tidy=true>>/opt/idp.install.properties && \


### PR DESCRIPTION
@marioreale has had problems building the image. Not sure about the real
problem, but it might be due to missing `--keyserver` option and thus
failing to download the appropriate key. This might help to resolve it.