### PR TITLE
Host-specific improvements

### DIFF
--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -107,6 +107,15 @@ RUN echo idp.no.tidy=true>>/opt/idp.install.properties && \
         -Didp.keystore.password=$SHIBBOLETH_PASSWORD_KEYSTORE \
         -Didp.noprompt=true
 
+# Shibboleth IdP -- copy host-specific configuration files
+COPY hosts/$SHIBBOLETH_HOSTNAME/attribute-filter.xml.test \
+     hosts/$SHIBBOLETH_HOSTNAME/attribute-resolver.xml.test \
+     hosts/$SHIBBOLETH_HOSTNAME/idp.properties.test \
+     hosts/$SHIBBOLETH_HOSTNAME/ldap.properties.test \
+     hosts/$SHIBBOLETH_HOSTNAME/metadata-providers.xml.test \
+     hosts/$SHIBBOLETH_HOSTNAME/relying-party.xml.test \
+     /opt/shibboleth-idp/conf/
+
 # Clean packages
 RUN apt-get -qq -y purge \
     wget \

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -86,7 +86,7 @@ ENV SHIBBOLETH_SCOPE=$SHIBBOLETH_SCOPE \
     SHIBBOLETH_PASSWORD_KEYSTORE=$SHIBBOLETH_PASSWORD_KEYSTORE
 
 # Jetty -- container dependent steps
-COPY jetty-keystore.sh certificates/$SHIBBOLETH_HOSTNAME.key.pem certificates/$SHIBBOLETH_HOSTNAME.crt.pem /tmp/
+COPY jetty-keystore.sh hosts/$SHIBBOLETH_HOSTNAME/key.pem hosts/$SHIBBOLETH_HOSTNAME/cert.pem /tmp/
 RUN echo $SHIBBOLETH_ENTITYID >> /opt/jetty/webapps/root/index.html && \
     /tmp/jetty-keystore.sh $JETTY_VERSION $PASSWORD_CERT_KEY $PASSWORD_PKCS12 $PASSWORD_KEYSTORE $SHIBBOLETH_HOSTNAME
 

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -118,13 +118,16 @@ RUN echo idp.no.tidy=true>>/opt/idp.install.properties && \
         -Didp.noprompt=true
 
 # Shibboleth IdP -- copy host-specific configuration files
-COPY hosts/$SHIBBOLETH_HOSTNAME/attribute-filter.xml.test \
-     hosts/$SHIBBOLETH_HOSTNAME/attribute-resolver.xml.test \
-     hosts/$SHIBBOLETH_HOSTNAME/idp.properties.test \
-     hosts/$SHIBBOLETH_HOSTNAME/ldap.properties.test \
-     hosts/$SHIBBOLETH_HOSTNAME/metadata-providers.xml.test \
-     hosts/$SHIBBOLETH_HOSTNAME/relying-party.xml.test \
+COPY hosts/$SHIBBOLETH_HOSTNAME/attribute-filter.xml \
+     hosts/$SHIBBOLETH_HOSTNAME/attribute-resolver.xml \
+     hosts/$SHIBBOLETH_HOSTNAME/ldap.properties \
+     hosts/$SHIBBOLETH_HOSTNAME/metadata-providers.xml \
+     hosts/$SHIBBOLETH_HOSTNAME/relying-party.xml \
      /opt/shibboleth-idp/conf/
+
+COPY hosts/$SHIBBOLETH_HOSTNAME/ldap-server.crt \
+     hosts/$SHIBBOLETH_HOSTNAME/metadata.eduid.cz.crt.pem \
+     /opt/shibboleth-idp/credentials/
 
 EXPOSE 8080 8443
 

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -64,6 +64,16 @@ RUN wget -q -P /opt/src/ https://shibboleth.net/downloads/identity-provider/$SHI
     gpg -q --verify /opt/src/shibboleth-identity-provider-$SHIBBOLETH_VERSION.tar.gz.asc && \
     tar -xzf /opt/src/shibboleth-identity-provider-$SHIBBOLETH_VERSION.tar.gz -C /opt
 
+# Clean packages
+RUN apt-get -qq -y purge \
+    wget \
+    gnupg2 \
+    dirmngr && \
+    apt-get -qq -y autoremove
+
+# Clean source codes
+RUN rm -rf /opt/src
+
 # Container dependent variables
 ## Jetty
 ARG PASSWORD_CERT_KEY
@@ -115,16 +125,6 @@ COPY hosts/$SHIBBOLETH_HOSTNAME/attribute-filter.xml.test \
      hosts/$SHIBBOLETH_HOSTNAME/metadata-providers.xml.test \
      hosts/$SHIBBOLETH_HOSTNAME/relying-party.xml.test \
      /opt/shibboleth-idp/conf/
-
-# Clean packages
-RUN apt-get -qq -y purge \
-    wget \
-    gnupg2 \
-    dirmngr && \
-    apt-get -qq -y autoremove
-
-# Clean source codes
-RUN rm -rf /opt/src
 
 EXPOSE 8080 8443
 

--- a/DOCKER/README.md
+++ b/DOCKER/README.md
@@ -3,8 +3,8 @@
 In case, you have:
 
 1. Working Docker environment. The official latest version required -- 17.09.0-ce.
-2. A certificate with the full chain in `certificates/$FQDN.crt.pem` file.
-3. A private key in `certificates/$FQDN.key.pem` file.
+2. A certificate with the full chain in `hosts/$FQDN/cert.pem` file.
+3. A private key in `hosts/$FQDN/key.pem` file.
 
 You just need to follow these steps:
 

--- a/DOCKER/buildenv.conf
+++ b/DOCKER/buildenv.conf
@@ -4,16 +4,16 @@ JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre"
 # Jetty
 JETTY_VERSION="9.3.20.v20170531"
 JETTY_KEY="2D0E1FB8FE4B68B4"
-PASSWORD_CERT_KEY="jo7ahrie6aecoog2Eeng"
+PASSWORD_CERT_KEY="ahkiph1Ahboh4uuG4Pha"
 PASSWORD_PKCS12="aiveibooch1Ohk9ahxi3"
 PASSWORD_KEYSTORE="oe7taiXiopiex2jusei8"
 
 # Shibboleth IdP
 SHIBBOLETH_VERSION="3.3.1"
 SHIBBOLETH_KEY="07CEEB8B"
-SHIBBOLETH_SCOPE="snotra.cesnet.cz"
-SHIBBOLETH_ENTITYID="https://snotra.cesnet.cz/idp/shibboleth"
-SHIBBOLETH_HOSTNAME="snotra.cesnet.cz"
+SHIBBOLETH_SCOPE="azog.cesnet.cz"
+SHIBBOLETH_ENTITYID="https://azog.cesnet.cz/idp/shibboleth_docker"
+SHIBBOLETH_HOSTNAME="azog.cesnet.cz"
 SHIBBOLETH_PASSWORD_SEALER="aif8ohx6sheetai0Gae1"
 SHIBBOLETH_PASSWORD_KEYSTORE="yifohToh5cafoonai5ie"
 

--- a/DOCKER/jetty-keystore.sh
+++ b/DOCKER/jetty-keystore.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# /tmp/$SHIBBOLETH_HOSTNAME.key.pem -- a private key
-# /tmp/$SHIBBOLETH_HOSTNAME.crt.pem -- a certificate with full chain
-# /tmp/jetty-cert.pkcs12            -- PKCS12 format
-# /opt/jetty/etc/keystore           -- final keystore for Jetty
+# /tmp/key.pem              -- a private key
+# /tmp/cert.pem             -- a certificate with full chain
+# /tmp/jetty-cert.pkcs12    -- PKCS12 format
+# /opt/jetty/etc/keystore   -- final keystore for Jetty
 #
 # $1    -- JETTY_VERSION set in Dockerfile
 # $2    -- a private key password
@@ -21,7 +21,7 @@ obfpass() {
     java -cp /opt/jetty-distribution-$JETTY_VERSION/lib/jetty-util-$JETTY_VERSION.jar org.eclipse.jetty.util.security.Password $1 2>&1 | grep OBF\:
 }
 
-openssl pkcs12 -export -inkey /tmp/$SHIBBOLETH_HOSTNAME.key.pem -in /tmp/$SHIBBOLETH_HOSTNAME.crt.pem -out /tmp/jetty-cert.pkcs12 -passin pass:$PASSWORDKEY -passout pass:$PASSWORDPKCS12
+openssl pkcs12 -export -inkey /tmp/key.pem -in /tmp/cert.pem -out /tmp/jetty-cert.pkcs12 -passin pass:$PASSWORDKEY -passout pass:$PASSWORDPKCS12
 rm -f /opt/jetty/etc/keystore
 keytool -importkeystore -srckeystore /tmp/jetty-cert.pkcs12 -srcstoretype PKCS12 -destkeystore /opt/jetty/etc/keystore -storepass $PASSWORDKEYSTORE -srcstorepass $PASSWORDPKCS12 -noprompt
 
@@ -33,5 +33,5 @@ sed -i.bak "s%#\ jetty.sslContext.keyStorePassword=.*%jetty.sslContext.keyStoreP
     s%#\ jetty.sslContext.trustStorePassword=.*%jetty.sslContext.trustStorePassword=$OBFPASS2%" \
     /opt/jetty/start.d/ssl.ini
 
-rm -f /tmp/$SHIBBOLETH_HOSTNAME.key.pem /tmp/$SHIBBOLETH_HOSTNAME.crt.pem /tmp/jetty-cert.pkcs12
+rm -f /tmp/key.pem /tmp/cert.pem /tmp/jetty-cert.pkcs12
 

--- a/DOCKER/run.sh
+++ b/DOCKER/run.sh
@@ -13,7 +13,7 @@ docker container run \
     --detach \
     --name stretch-shib-idp-test01 \
     --hostname stretch-shib-idp-test01 \
-    -p 8080:8080 -p 8443:8443 \
+    -p 80:8080 -p 443:8443 \
     -v /var/tmp/docker-logs-jetty:/opt/jetty/logs \
     -v /var/tmp/docker-logs-shibboleth:/opt/shibboleth-idp/logs \
     stretch-shib-idp-test01$TAG


### PR DESCRIPTION
All host-specific configuration files should be placed within fqdn-called directory.